### PR TITLE
パスワード再設定画面の追加

### DIFF
--- a/src/static/css/common/base.css
+++ b/src/static/css/common/base.css
@@ -11,15 +11,12 @@ a img:hover {
 }
 
 .page {
-    /* max-width: 1440px; ヘッダーの帯を画面幅いっぱいにするテスト */
     min-height: 100vh;
-    /* margin: 0 auto; ヘッダーの帯を画面幅いっぱいにするテスト */
 }
 
 .container {
     max-width: 1200px;
     height: 64px;
-    /* margin: 0 10%; ヘッダーの帯を画面幅いっぱいにするテスト */
     margin: 0 auto;
 }
 
@@ -121,7 +118,6 @@ footer {
 .footer-wrapper {
     max-width: 1200px;
     height: 32px;
-    /* margin: 0 10%; フッターの帯を画面幅いっぱいにするテスト */
     margin: 0 auto;
     display: flex;
     align-items: center;

--- a/src/static/css/users/password_reset.css
+++ b/src/static/css/users/password_reset.css
@@ -1,0 +1,27 @@
+/* 共通CSSに切り出してmarginとgapのみ指定 */
+.auth-wrapper {
+    margin: 93px auto 180px;
+    gap: 24px;
+}
+/* ここまで */
+
+.auth-wrapper h2 {
+    font-size: 1.75rem;
+    margin: 0 auto 40px;
+}
+
+.password-reset-description {
+    margin:0;
+    text-align: center;
+}
+
+.auth-form {
+    margin-top: 16px;
+}
+
+/* 共通CSSに切り出してbuttonタグのborderだけ個別に指定 */
+.btn {
+    border: none;
+    margin-top: 40px;
+}
+/* ここまで */

--- a/src/templates/users/password-reset.html
+++ b/src/templates/users/password-reset.html
@@ -1,11 +1,41 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>password-reset</title>
-</head>
-<body>
-    <h1>password-reset</h1>
-</body>
-</html>
+{% extends "common/base.html" %}
+{% load static %}
+
+{% block title %}パスワード再設定{% endblock %}
+
+{% block page_css %}
+<link rel="stylesheet" href="{% static 'css/users/password_reset.css' %}">
+{% endblock %}
+
+{% block content %}
+<form method="post" action="{% url 'users:password-reset' %}">
+{% csrf_token %}
+
+    <div class="auth-wrapper">
+        <h2>パスワード再設定</h2>
+
+        <p class="password-reset-description">
+            登録したメールアドレスを入力して、<br>
+            パスワード再設定ボタンをクリックしてください。
+        </p>
+        <p class="password-reset-description">
+            送信したメールに記載されたリンクから、<br>
+            パスワードを再設定することができます。
+        </p>
+
+        <div class="auth-form">
+            <label for="password-reset-email">メールアドレス</label>
+            <input type="email" name="email" id="password-reset-email"
+             class="{% if errors.email %}is-error{% endif %}" required>
+            <!-- エラーメッセージの仕様が決まったら編集する -->
+            {% if errors.email %}
+            <p class="error-message">{{ errors.email }}</p>
+            {% endif %}
+        </div>
+        
+        <div>
+            <button class="btn" type="submit">パスワード再設定</button>
+        </div>
+    </div>
+</form>
+{% endblock %}


### PR DESCRIPTION
### 概要
パスワードリセット画面のHTML,CSSを追加。

### 変更内容
- HTML：password-reset.htmlを修正
- CSS：password_reset.cssを追加、以下を修正
 - base.cssにおいて、ヘッダー・フッターの帯を画面幅いっぱいに表示するために、暫定的な記載で変更していた部分を完全削除

### 関連Issue
- Issue番号：#20