### PR TITLE
signup時のusernameのUniqueバリデーション解除

### DIFF
--- a/src/apps/users/forms/signup.py
+++ b/src/apps/users/forms/signup.py
@@ -12,3 +12,8 @@ class SignUpForm(UserCreationForm):
         if User.objects.filter(email=email).exists():
             raise forms.ValidationError('このメールアドレスは既に登録されています')
         return email.lower().strip()
+
+    # UserCreationFormのusernameのUnique設定解除
+    def clean_username(self):
+        username = self.cleaned_data.get('username')
+        return username


### PR DESCRIPTION
### 概要
signup時のusernameのUniqueバリデーション解除

### 変更内容
- forms/signup.pyにclean_usernameを上書きして、Uniqueバリデーション処理を解除

### 関連Issue
- Issue番号（: #17 ）
