### PR TITLE
statusによって返すデータの変更

### DIFF
--- a/src/apps/runs/views/records.py
+++ b/src/apps/runs/views/records.py
@@ -13,15 +13,8 @@ from django.views import View
 from apps.runs.models import ProgramRun, TimerRun
 
 
-# recordsには「確定した記録」だけ出す（途中は出さない）
-ALLOWED_STATUSES = {
-    TimerRun.Status.FINISHED,
-    TimerRun.Status.SKIPPED,
-    TimerRun.Status.INTERRUPTED,
-}
-
-#集中のみ
 FOCUS_CATEGORY_VALUES = {"focus", "集中"}  
+
 
 def _iso_local(dt):
     """JSONに返す時刻はJST(+09:00)で返す"""
@@ -59,7 +52,7 @@ class RecordsDataView(LoginRequiredMixin, View):
         if target_date is None:
             target_date = timezone.localdate()
 
-        # その日の [00:00, 24:00) 範囲（TIME_ZONE基準=JST想定）
+        # recordsは0時区切り：[00:00, 24:00)（JST）
         tz = timezone.get_current_timezone()
         range_from = timezone.make_aware(datetime.combine(target_date, time.min), tz)
         range_to = range_from + timedelta(days=1)
@@ -70,8 +63,8 @@ class RecordsDataView(LoginRequiredMixin, View):
             .filter(program_run__user=request.user)
             .filter(started_at__isnull=False)
             .filter(started_at__gte=range_from, started_at__lt=range_to)
-            #確定した記録だけ
-            .filter(status__in=ALLOWED_STATUSES)
+            # ★ pending（初期状態）だけ除外 → running/paused/finished/skipped/interrupted は返す
+            .exclude(status=TimerRun.Status.PENDING)
         )
 
         # 集中のみ
@@ -88,7 +81,6 @@ class RecordsDataView(LoginRequiredMixin, View):
                 "daily_total_elapsed_sec": 0,
             })
 
-        # 対象TimerRunから program_run を逆算
         program_run_ids = sorted({tr.program_run_id for tr in timer_runs_list})
         program_runs = list(
             ProgramRun.objects
@@ -96,7 +88,6 @@ class RecordsDataView(LoginRequiredMixin, View):
             .order_by("-started_at", "-id")
         )
 
-        # programごとの合計秒 & 日合計秒
         totals_by_program = defaultdict(int)
         daily_total = 0
         for tr in timer_runs_list:
@@ -104,7 +95,6 @@ class RecordsDataView(LoginRequiredMixin, View):
             totals_by_program[tr.program_run_id] += sec
             daily_total += sec
 
-        # programs（秒のみ）
         programs = []
         for pr in program_runs:
             program_name = (
@@ -123,7 +113,6 @@ class RecordsDataView(LoginRequiredMixin, View):
                 ),
             })
 
-        # timer_runs（秒のみ／started_at を runninged_at で返す互換）
         timer_runs = []
         for tr in timer_runs_list:
             timer_name = getattr(tr, "timer_name_snapshot", None) or "（no name）"
@@ -134,7 +123,10 @@ class RecordsDataView(LoginRequiredMixin, View):
                 "program_run_id": tr.program_run_id,
                 "timer_run_id": tr.id,
                 "timer_name": timer_name,
-                "runninged_at": _iso_local(started),
+
+                #修正：runninged_at → started_at
+                "started_at": _iso_local(started),
+
                 "ended_at": _iso_local(ended),
                 "updated_at": (
                     _iso_local(getattr(tr, "updated_at", None))
@@ -143,6 +135,9 @@ class RecordsDataView(LoginRequiredMixin, View):
                 ),
                 "elapsed_sec": _safe_int(getattr(tr, "elapsed_sec", 0) or 0),
                 "memo": getattr(tr, "memo", None),
+
+                # （任意）フロントで途中表示等に使うなら status も返す
+                "status": getattr(tr, "status", None),
             })
 
         return JsonResponse({
@@ -151,5 +146,4 @@ class RecordsDataView(LoginRequiredMixin, View):
             "timer_runs": timer_runs,
             "daily_total_elapsed_sec": int(daily_total),
         })
-
 


### PR DESCRIPTION
### 概要
statusについてpending以外は記録されるように修正、runningedをstarted_atに修正しました。

### 変更内容
- 変更点1
- 変更点2
- 変更点3

### 関連Issue
- Issue番号（例: #123）

### 関連する問題（必要に応じて）

### スクリーンショット（必要に応じて）
