### PR TITLE
elapsec_secの加算処理を更新に修正、total_elapsed_secの過大計上を修正

### DIFF
--- a/src/apps/runs/services/program_runs/lifecycle.py
+++ b/src/apps/runs/services/program_runs/lifecycle.py
@@ -6,119 +6,125 @@ from apps.runs.models import ProgramRun, TimerRun
 # プログラムstart（初回実行）
 @transaction.atomic
 def status_start(program_run_id, timer_run_id):
+    now = timezone.now()
     program_run = ProgramRun.objects.select_for_update().get(id=program_run_id)
     program_run.status = ProgramRun.Status.RUNNING
-    program_run.started_at = timezone.now()
-    program_run.updated_at = timezone.now()
+    program_run.started_at = now
+    program_run.updated_at = now
     program_run.save()
 
     timer_run = TimerRun.objects.select_for_update().get(id=timer_run_id, program_run_id=program_run_id)
     timer_run.status = TimerRun.Status.RUNNING
-    timer_run.started_at = timezone.now()
-    timer_run.updated_at = timezone.now()
+    timer_run.started_at = now
+    timer_run.updated_at = now
     timer_run.save()
 
 # プログラムpause（一時停止）
 @transaction.atomic
 def status_pause(program_run_id, timer_run_id, elapsed_sec:int):
+    now = timezone.now()
     program_run = ProgramRun.objects.select_for_update().get(id=program_run_id)
+    timer_run = TimerRun.objects.select_for_update().get(id=timer_run_id, program_run_id=program_run_id)
+
     program_run.status = ProgramRun.Status.PAUSED
-    program_run.paused_at = timezone.now()
-    program_run.total_elapsed_sec += elapsed_sec
-    program_run.updated_at = timezone.now()
+    program_run.paused_at = now
+    program_run.total_elapsed_sec += max(0, elapsed_sec - timer_run.elapsed_sec)
+    program_run.updated_at = now
     program_run.save()
 
-    timer_run = TimerRun.objects.select_for_update().get(id=timer_run_id, program_run_id=program_run_id)
     timer_run.status = TimerRun.Status.PAUSED
-    timer_run.paused_at = timezone.now()
-    timer_run.elapsed_sec += elapsed_sec
-    timer_run.updated_at = timezone.now()
+    timer_run.paused_at = now
+    timer_run.elapsed_sec = elapsed_sec
+    timer_run.updated_at = now
     timer_run.save()
 
 # プログラムresume（再開）
 @transaction.atomic
 def status_resume(program_run_id, timer_run_id):
+    now = timezone.now()
     program_run = ProgramRun.objects.select_for_update().get(id=program_run_id)
     program_run.status = ProgramRun.Status.RUNNING
-    program_run.updated_at = timezone.now()
+    program_run.updated_at = now
     program_run.save()
 
     timer_run = TimerRun.objects.select_for_update().get(id=timer_run_id, program_run_id=program_run_id)
     timer_run.status = TimerRun.Status.RUNNING
-    timer_run.updated_at = timezone.now()
+    timer_run.updated_at = now
     timer_run.save()
 
 # プログラムnext（自動遷移）
 @transaction.atomic
 def status_next(program_run_id, finished_timer_run_id, elapsed_sec:int, next_timer_run_id):
+    now = timezone.now()
     program_run = ProgramRun.objects.select_for_update().get(id=program_run_id)
-    program_run.total_elapsed_sec += elapsed_sec
-    program_run.updated_at = timezone.now()
-    program_run.save()
-
     timer_run = TimerRun.objects.select_for_update().get(id=finished_timer_run_id, program_run_id=program_run_id)
+
+    program_run.total_elapsed_sec += max(0, elapsed_sec - timer_run.elapsed_sec)
+
     timer_run.status = TimerRun.Status.FINISHED
-    timer_run.ended_at = timezone.now()
-    timer_run.elapsed_sec += elapsed_sec
-    timer_run.updated_at = timezone.now()
+    timer_run.ended_at = now
+    timer_run.elapsed_sec = elapsed_sec
+    timer_run.updated_at = now
     timer_run.save()
 
     if next_timer_run_id:
         next_timer = TimerRun.objects.select_for_update().get(id=next_timer_run_id, program_run_id=program_run_id)
         next_timer.status = TimerRun.Status.RUNNING
-        next_timer.started_at = timezone.now()
-        next_timer.updated_at = timezone.now()
+        next_timer.started_at = now
+        next_timer.updated_at = now
         next_timer.save()
 
     else:
-        program_run = ProgramRun.objects.select_for_update().get(id=program_run_id)
         program_run.status = ProgramRun.Status.FINISHED
-        program_run.ended_at = timezone.now()
-        program_run.updated_at = timezone.now()
-        program_run.save()
+        program_run.ended_at = now
+
+    program_run.updated_at = now
+    program_run.save()
 
 # プログラムskip（スキップ）
 @transaction.atomic
 def status_skip(program_run_id, finished_timer_run_id, elapsed_sec:int, next_timer_run_id):
+    now = timezone.now()
     program_run = ProgramRun.objects.select_for_update().get(id=program_run_id)
-    program_run.total_elapsed_sec += elapsed_sec
-    program_run.updated_at = timezone.now()
-    program_run.save()
-
     timer_run = TimerRun.objects.select_for_update().get(id=finished_timer_run_id, program_run_id=program_run_id)
+
+    program_run.total_elapsed_sec += max(0, elapsed_sec - timer_run.elapsed_sec)
+
     timer_run.status = TimerRun.Status.SKIPPED
-    timer_run.ended_at = timezone.now()
-    timer_run.elapsed_sec += elapsed_sec
-    timer_run.updated_at = timezone.now()
+    timer_run.ended_at = now
+    timer_run.elapsed_sec = elapsed_sec
+    timer_run.updated_at = now
     timer_run.save()
 
     if next_timer_run_id:
         next_timer = TimerRun.objects.select_for_update().get(id=next_timer_run_id, program_run_id=program_run_id)
         next_timer.status = TimerRun.Status.RUNNING
-        next_timer.started_at = timezone.now()
-        next_timer.updated_at = timezone.now()
+        next_timer.started_at = now
+        next_timer.updated_at = now
         next_timer.save()
 
     else:
-        program_run = ProgramRun.objects.select_for_update().get(id=program_run_id)
         program_run.status = ProgramRun.Status.FINISHED
-        program_run.ended_at = timezone.now()
-        program_run.updated_at = timezone.now()
-        program_run.save()
+        program_run.ended_at = now
+
+    program_run.updated_at = now
+    program_run.save()
 
 # プログラムinterrupt（中断）
 @transaction.atomic
 def status_interrupt(program_run_id, timer_run_id, elapsed_sec:int):
+    now = timezone.now()
     program_run = ProgramRun.objects.select_for_update().get(id=program_run_id)
+    timer_run = TimerRun.objects.select_for_update().get(id=timer_run_id, program_run_id=program_run_id)
+
     program_run.status = ProgramRun.Status.INTERRUPTED
-    program_run.paused_at = timezone.now()
-    program_run.total_elapsed_sec += elapsed_sec
-    program_run.updated_at = timezone.now()
+    program_run.paused_at = now
+    program_run.total_elapsed_sec += max(0, elapsed_sec - timer_run.elapsed_sec)
+    program_run.updated_at = now
     program_run.save()
 
-    timer_run = TimerRun.objects.select_for_update().get(id=timer_run_id, program_run_id=program_run_id)
     timer_run.status = TimerRun.Status.INTERRUPTED
-    timer_run.paused_at = timezone.now()
-    timer_run.elapsed_sec += elapsed_sec
-    timer_run.updated_at = timezone.now()
+    timer_run.paused_at = now
+    timer_run.elapsed_sec = elapsed_sec
+    timer_run.updated_at = now
     timer_run.save()

--- a/src/apps/runs/services/program_runs/progress.py
+++ b/src/apps/runs/services/program_runs/progress.py
@@ -5,11 +5,15 @@ from apps.runs.models import ProgramRun, TimerRun
 
 # プログラムprogress（自動保存）
 @transaction.atomic
-def runs_progress(program_run_id, timer_run_id):
+def runs_progress(program_run_id, timer_run_id, elapsed_sec:int):
+    now = timezone.now()
     program_run = ProgramRun.objects.select_for_update().get(id=program_run_id)
+    timer_run = TimerRun.objects.select_for_update().get(id=timer_run_id, program_run_id=program_run_id)
+
+    program_run.total_elapsed_sec += max(0, elapsed_sec - timer_run.elapsed_sec)
     program_run.updated_at = timezone.now()
     program_run.save()
 
-    timer_run = TimerRun.objects.select_for_update().get(id=timer_run_id, program_run_id=program_run_id)
+    timer_run.elapsed_sec = elapsed_sec
     timer_run.updated_at = timezone.now()
     timer_run.save()

--- a/src/apps/runs/views/program_runs/progress.py
+++ b/src/apps/runs/views/program_runs/progress.py
@@ -15,7 +15,8 @@ class ProgramProgressView(LoginRequiredMixin, View):
         try:
             body = json.loads(request.body)
             current_timer_run_id = body.get('current_timer_run_id')
-            runs_progress(program_run_id, current_timer_run_id)
+            elapsed_sec = int(body.get('elapsed_sec'))
+            runs_progress(program_run_id, current_timer_run_id, elapsed_sec)
             program_run, timer_run = selector_progress_programRun_timerRun(program_run_id, current_timer_run_id)
             runs_data = serialize_progress_runs(program_run, timer_run)
             return JsonResponse({'runs_data': runs_data})


### PR DESCRIPTION
### 概要
elapsec_secの加算処理を更新に修正、total_elapsed_secの過大計上を修正、progress時にもelapsed_secを定期保存するように修正

### 変更内容
- バックエンド側のelapsed_secの保存ロジックを修正
- admin管理画面上でelapsed_secが正常に計上されることを確認