### PR TITLE
ended_atを持たない記録の表示方法の修正

### DIFF
--- a/src/apps/runs/views/records.py
+++ b/src/apps/runs/views/records.py
@@ -13,7 +13,8 @@ from django.views import View
 from apps.runs.models import ProgramRun, TimerRun
 
 
-FOCUS_CATEGORY_VALUES = {"focus", "集中"}  
+# 集中のみ（DB値に合わせて調整）
+FOCUS_CATEGORY_VALUES = {"focus", "集中"}
 
 
 def _iso_local(dt):
@@ -57,6 +58,7 @@ class RecordsDataView(LoginRequiredMixin, View):
         range_from = timezone.make_aware(datetime.combine(target_date, time.min), tz)
         range_to = range_from + timedelta(days=1)
 
+        # TimerRun抽出：当日開始・pending除外・集中のみ
         tr_qs = (
             TimerRun.objects
             .select_related("program_run")
@@ -65,9 +67,10 @@ class RecordsDataView(LoginRequiredMixin, View):
             .filter(started_at__gte=range_from, started_at__lt=range_to)
             # ★ pending（初期状態）だけ除外 → running/paused/finished/skipped/interrupted は返す
             .exclude(status=TimerRun.Status.PENDING)
+           
         )
 
-        # 集中のみ
+        # 集中のみ（休憩など除外）
         if hasattr(TimerRun, "category_snapshot"):
             tr_qs = tr_qs.filter(category_snapshot__in=FOCUS_CATEGORY_VALUES)
 
@@ -81,6 +84,7 @@ class RecordsDataView(LoginRequiredMixin, View):
                 "daily_total_elapsed_sec": 0,
             })
 
+        # 対象TimerRunから program_run を逆算
         program_run_ids = sorted({tr.program_run_id for tr in timer_runs_list})
         program_runs = list(
             ProgramRun.objects
@@ -88,6 +92,7 @@ class RecordsDataView(LoginRequiredMixin, View):
             .order_by("-started_at", "-id")
         )
 
+        # programごとの合計秒 & 日合計秒（このレスポンスに含めるタイマーだけで計算）
         totals_by_program = defaultdict(int)
         daily_total = 0
         for tr in timer_runs_list:
@@ -95,6 +100,7 @@ class RecordsDataView(LoginRequiredMixin, View):
             totals_by_program[tr.program_run_id] += sec
             daily_total += sec
 
+        # programs
         programs = []
         for pr in program_runs:
             program_name = (
@@ -113,21 +119,28 @@ class RecordsDataView(LoginRequiredMixin, View):
                 ),
             })
 
+        # timer_runs
+        # 方針：
+        # - ended_at が null の場合、フロントで "--:--" 表示
+        # - ended_at が null で paused_at がある場合、フロントが paused_at を代替表示できるよう paused_at を返す
         timer_runs = []
         for tr in timer_runs_list:
             timer_name = getattr(tr, "timer_name_snapshot", None) or "（no name）"
             started = getattr(tr, "started_at", None)
             ended = getattr(tr, "ended_at", None)
+            paused = getattr(tr, "paused_at", None)
 
             timer_runs.append({
                 "program_run_id": tr.program_run_id,
                 "timer_run_id": tr.id,
                 "timer_name": timer_name,
 
-                #修正：runninged_at → started_at
+                # 開始時刻（キー名は started_at に統一）
                 "started_at": _iso_local(started),
 
+                # 完了時刻（無ければ null のまま返す）
                 "ended_at": _iso_local(ended),
+
                 "updated_at": (
                     _iso_local(getattr(tr, "updated_at", None))
                     or _iso_local(ended)
@@ -136,8 +149,8 @@ class RecordsDataView(LoginRequiredMixin, View):
                 "elapsed_sec": _safe_int(getattr(tr, "elapsed_sec", 0) or 0),
                 "memo": getattr(tr, "memo", None),
 
-                # （任意）フロントで途中表示等に使うなら status も返す
-                "status": getattr(tr, "status", None),
+                "status": tr.status,
+                "status_label": tr.get_status_display(),  
             })
 
         return JsonResponse({

--- a/src/static/js/runs/records.js
+++ b/src/static/js/runs/records.js
@@ -40,12 +40,17 @@ function escapeHtml(str) {
 }
 
 function formatHm(isoString) {
+  if (!isoString) return "";
   const d = new Date(isoString);
-  const hh = String(d.getHours()).padStart(2, "0");
-  const mm = String(d.getMinutes()).padStart(2, "0");
-  return `${hh}:${mm}`;
+  if (Number.isNaN(d.getTime())) return "";
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
+function formatEnd(r) {
+  // finished だけ終了時刻、それ以外は日本語ラベル
+  if (r.status === "finished") return r.ended_at ? formatHm(r.ended_at) : "";
+  return r.status_label || "";
+}
 function formatDuration(sec) {
   const totalMin = Math.floor((sec ?? 0) / 60);
   const h = Math.floor(totalMin / 60);
@@ -166,7 +171,7 @@ function renderTimers() {
       class="recordedCard recordedTimer"
       data-timer-run-id="${r.timer_run_id}">
       <p class="startFinish">
-        <span>${formatHm(r.started_at)}</span> ~ <span>${formatHm(r.ended_at)}</span>
+        <span>${formatHm(r.started_at)}</span> ~ <span>${escapeHtml(formatEnd(r))}</span>
       </p>
       <p class="timerName">${escapeHtml(r.timer_name)}</p>
       <p class="elapsedSec">${formatDuration(r.elapsed_sec)}</p>


### PR DESCRIPTION
### 概要
ended_atを持たないstatusの記録はステータスの日本語ラベルを表記する(完了以外)

### 変更内容
- 変更点1
- 変更点2
- 変更点3

### 関連Issue
- Issue番号（例: #123）

### 関連する問題（必要に応じて）

### スクリーンショット（必要に応じて）
