### PR TITLE
プロフィールの変更処理の追加、Skip時のprogram_runs.statusでrunning, pausedに条件分岐

### DIFF
--- a/src/apps/runs/services/program_runs/lifecycle.py
+++ b/src/apps/runs/services/program_runs/lifecycle.py
@@ -68,6 +68,7 @@ def status_next(program_run_id, finished_timer_run_id, elapsed_sec:int, next_tim
     timer_run.save()
 
     if next_timer_run_id:
+        program_run.status = ProgramRun.Status.RUNNING
         next_timer = TimerRun.objects.select_for_update().get(id=next_timer_run_id, program_run_id=program_run_id)
         next_timer.status = TimerRun.Status.RUNNING
         next_timer.started_at = now
@@ -97,6 +98,7 @@ def status_skip(program_run_id, finished_timer_run_id, elapsed_sec:int, next_tim
     timer_run.save()
 
     if next_timer_run_id:
+        program_run.status = ProgramRun.Status.RUNNING
         next_timer = TimerRun.objects.select_for_update().get(id=next_timer_run_id, program_run_id=program_run_id)
         next_timer.status = TimerRun.Status.RUNNING
         next_timer.started_at = now

--- a/src/apps/runs/services/program_runs/lifecycle.py
+++ b/src/apps/runs/services/program_runs/lifecycle.py
@@ -98,9 +98,12 @@ def status_skip(program_run_id, finished_timer_run_id, elapsed_sec:int, next_tim
     timer_run.save()
 
     if next_timer_run_id:
-        program_run.status = ProgramRun.Status.RUNNING
         next_timer = TimerRun.objects.select_for_update().get(id=next_timer_run_id, program_run_id=program_run_id)
-        next_timer.status = TimerRun.Status.RUNNING
+        if program_run.status == ProgramRun.Status.RUNNING:
+            next_timer.status = TimerRun.Status.RUNNING
+        elif program_run.status == ProgramRun.Status.PAUSED:
+            next_timer.status = TimerRun.Status.PAUSED
+
         next_timer.started_at = now
         next_timer.updated_at = now
         next_timer.save()

--- a/src/apps/runs/views/program_runs/interrupt.py
+++ b/src/apps/runs/views/program_runs/interrupt.py
@@ -1,5 +1,7 @@
 # プログラムのinterrupt（中断）（POST）
 import json
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from django.http import JsonResponse
 from django.shortcuts import render, redirect
 from django.views import View
@@ -8,6 +10,7 @@ from ...selectors.program_runs import selector_interrupt_programRun_timerRun
 from ...services.program_runs.lifecycle import status_interrupt
 from ...serializers.program_runs import serialize_interrupt_runs
 
+@method_decorator(csrf_exempt, name='dispatch')
 class ProgramInterruptView(LoginRequiredMixin, View):
     def post(self, request, program_run_id):
         if not request.body:

--- a/src/apps/users/forms/profile/profile_email.py
+++ b/src/apps/users/forms/profile/profile_email.py
@@ -8,7 +8,6 @@ class ProfileEmailForm(ModelForm):
         fields = ['email']
 
     def clean_email(self):
-        print('emailバリデーション')
         email = self.cleaned_data.get('email')
         if User.objects.filter(email=email).exists():
             raise forms.ValidationError('このメールアドレスは既に登録されています')

--- a/src/apps/users/forms/profile/profile_email.py
+++ b/src/apps/users/forms/profile/profile_email.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.forms import ModelForm
 from ...models.users import User
 
@@ -5,4 +6,10 @@ class ProfileEmailForm(ModelForm):
     class Meta:
         model = User
         fields = ['email']
-        
+
+    def clean_email(self):
+        print('emailバリデーション')
+        email = self.cleaned_data.get('email')
+        if User.objects.filter(email=email).exists():
+            raise forms.ValidationError('このメールアドレスは既に登録されています')
+        return email.lower().strip()

--- a/src/apps/users/forms/profile/profile_email.py
+++ b/src/apps/users/forms/profile/profile_email.py
@@ -1,0 +1,8 @@
+from django.forms import ModelForm
+from ...models.users import User
+
+class ProfileEmailForm(ModelForm):
+    class Meta:
+        model = User
+        fields = ['email']
+        

--- a/src/apps/users/forms/profile/profile_email.py
+++ b/src/apps/users/forms/profile/profile_email.py
@@ -1,4 +1,3 @@
-from django import forms
 from django.forms import ModelForm
 from ...models.users import User
 
@@ -6,9 +5,3 @@ class ProfileEmailForm(ModelForm):
     class Meta:
         model = User
         fields = ['email']
-
-    def clean_email(self):
-        email = self.cleaned_data.get('email')
-        if User.objects.filter(email=email).exists():
-            raise forms.ValidationError('このメールアドレスは既に登録されています')
-        return email.lower().strip()

--- a/src/apps/users/forms/profile/profile_password.py
+++ b/src/apps/users/forms/profile/profile_password.py
@@ -1,1 +1,0 @@
-from django.contrib.auth.forms import PasswordChangeForm

--- a/src/apps/users/forms/profile/profile_password.py
+++ b/src/apps/users/forms/profile/profile_password.py
@@ -1,0 +1,1 @@
+from django.contrib.auth.forms import PasswordChangeForm

--- a/src/apps/users/forms/profile/profile_username.py
+++ b/src/apps/users/forms/profile/profile_username.py
@@ -1,0 +1,9 @@
+from django.forms import ModelForm
+from ...models.users import User
+from django import forms
+
+class ProfileUsernameForm(ModelForm):
+    class Meta:
+        model = User
+        fields = ['username']
+

--- a/src/apps/users/forms/profile/profile_username.py
+++ b/src/apps/users/forms/profile/profile_username.py
@@ -1,6 +1,5 @@
 from django.forms import ModelForm
 from ...models.users import User
-from django import forms
 
 class ProfileUsernameForm(ModelForm):
     class Meta:

--- a/src/apps/users/urls.py
+++ b/src/apps/users/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
         name='password-reset-complete'
         ),
     path('profile/', profile.ProfileView.as_view(), name='profile'),
-    path('profile/email/', profile_email.ProfileEmailView.as_view(), name='profile-email'),
+    path('profile/<int:pk>/email/', profile_email.ProfileEmailView.as_view(), name='profile-email'),
     path('profile/username/', profile_username.ProfileUsernameView.as_view(), name='profile-username'),
     path('profile/password/', profile_password.ProfilePasswordView.as_view(), name='profile-password'),
 ]

--- a/src/apps/users/urls.py
+++ b/src/apps/users/urls.py
@@ -30,6 +30,6 @@ urlpatterns = [
         ),
     path('profile/', profile.ProfileView.as_view(), name='profile'),
     path('profile/<int:pk>/email/', profile_email.ProfileEmailView.as_view(), name='profile-email'),
-    path('profile/username/', profile_username.ProfileUsernameView.as_view(), name='profile-username'),
-    path('profile/password/', profile_password.ProfilePasswordView.as_view(), name='profile-password'),
+    path('profile/<int:pk>/username/', profile_username.ProfileUsernameView.as_view(), name='profile-username'),
+    path('profile/<int:pk>/password/', profile_password.ProfilePasswordView.as_view(), name='profile-password'),
 ]

--- a/src/apps/users/views/profile/profile_email.py
+++ b/src/apps/users/views/profile/profile_email.py
@@ -8,6 +8,14 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from ...models.users import User
 from ...forms.profile.profile_email import ProfileEmailForm
 
+def _push_form_errors(request, form):
+    for field, errors in form.errors.items():
+        for e in errors:
+            if field == '__all__':
+                messages.error(request, e)
+            else:
+                messages.error(request, f'{form.fields[field].label or field}: {e}')
+
 class ProfileEmailView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
     model = User
     form_class = ProfileEmailForm
@@ -15,5 +23,5 @@ class ProfileEmailView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
     success_message = 'emailの変更が完了しました'
 
     def form_invalid(self, form):
-        messages.error(self.request, 'このメールアドレスは既に登録されています')
+        _push_form_errors(self.request, form)
         return redirect('users:profile')

--- a/src/apps/users/views/profile/profile_email.py
+++ b/src/apps/users/views/profile/profile_email.py
@@ -1,5 +1,6 @@
+from django.contrib import messages
 from django.shortcuts import render, redirect
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse_lazy
 from django.contrib.messages.views import SuccessMessageMixin
 from django.views import View
 from django.views.generic.edit import UpdateView
@@ -14,5 +15,5 @@ class ProfileEmailView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
     success_message = 'emailの変更が完了しました'
 
     def form_invalid(self, form):
+        messages.error(self.request, 'このメールアドレスは既に登録されています')
         return redirect('users:profile')
-

--- a/src/apps/users/views/profile/profile_email.py
+++ b/src/apps/users/views/profile/profile_email.py
@@ -1,7 +1,18 @@
 from django.shortcuts import render, redirect
+from django.urls import reverse, reverse_lazy
+from django.contrib.messages.views import SuccessMessageMixin
 from django.views import View
+from django.views.generic.edit import UpdateView
 from django.contrib.auth.mixins import LoginRequiredMixin
+from ...models.users import User
+from ...forms.profile.profile_email import ProfileEmailForm
 
-class ProfileEmailView(LoginRequiredMixin, View):
-    def post(self, request, *args, **kwargs):
-        pass
+class ProfileEmailView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
+    model = User
+    form_class = ProfileEmailForm
+    success_url = reverse_lazy('users:profile')
+    success_message = 'emailの変更が完了しました'
+
+    def form_invalid(self, form):
+        return redirect('users:profile')
+

--- a/src/apps/users/views/profile/profile_password.py
+++ b/src/apps/users/views/profile/profile_password.py
@@ -1,7 +1,15 @@
+from django.contrib import messages
 from django.shortcuts import render, redirect
+from django.urls import reverse_lazy
+from django.contrib.messages.views import SuccessMessageMixin
 from django.views import View
+from django.contrib.auth.views import PasswordChangeView
 from django.contrib.auth.mixins import LoginRequiredMixin
 
-class ProfilePasswordView(LoginRequiredMixin, View):
-    def post(self, request, *args, **kwargs):
-        pass
+class ProfilePasswordView(LoginRequiredMixin, SuccessMessageMixin, PasswordChangeView):
+    success_url = reverse_lazy('users:profile')
+    success_message = 'パスワードの変更が完了しました'
+
+    def form_invalid(self, form):
+        messages.error(self.request, 'エラー')
+        return redirect('users:profile')

--- a/src/apps/users/views/profile/profile_password.py
+++ b/src/apps/users/views/profile/profile_password.py
@@ -6,10 +6,18 @@ from django.views import View
 from django.contrib.auth.views import PasswordChangeView
 from django.contrib.auth.mixins import LoginRequiredMixin
 
+def _push_form_errors(request, form):
+    for field, errors in form.errors.items():
+        for e in errors:
+            if field == '__all__':
+                messages.error(request, e)
+            else:
+                messages.error(request, f'{form.fields[field].label or field}: {e}')
+
 class ProfilePasswordView(LoginRequiredMixin, SuccessMessageMixin, PasswordChangeView):
     success_url = reverse_lazy('users:profile')
     success_message = 'パスワードの変更が完了しました'
 
     def form_invalid(self, form):
-        messages.error(self.request, 'エラー')
+        _push_form_errors(self.request, form)
         return redirect('users:profile')

--- a/src/apps/users/views/profile/profile_username.py
+++ b/src/apps/users/views/profile/profile_username.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.shortcuts import render, redirect
 from django.urls import reverse_lazy
 from django.contrib.messages.views import SuccessMessageMixin
@@ -7,6 +8,14 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from ...models.users import User
 from ...forms.profile.profile_username import ProfileUsernameForm
 
+def _push_form_errors(request, form):
+    for field, errors in form.errors.items():
+        for e in errors:
+            if field == '__all__':
+                messages.error(request, e)
+            else:
+                messages.error(request, f'{form.fields[field].label or field}: {e}')
+
 class ProfileUsernameView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
     model = User
     form_class = ProfileUsernameForm
@@ -14,4 +23,5 @@ class ProfileUsernameView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
     success_message = 'ユーザ名の変更が完了しました'
 
     def form_invalid(self, form):
+        _push_form_errors(self.request, form)
         return redirect('users:profile')

--- a/src/apps/users/views/profile/profile_username.py
+++ b/src/apps/users/views/profile/profile_username.py
@@ -1,7 +1,17 @@
 from django.shortcuts import render, redirect
+from django.urls import reverse_lazy
+from django.contrib.messages.views import SuccessMessageMixin
 from django.views import View
+from django.views.generic.edit import UpdateView
 from django.contrib.auth.mixins import LoginRequiredMixin
+from ...models.users import User
+from ...forms.profile.profile_username import ProfileUsernameForm
 
-class ProfileUsernameView(LoginRequiredMixin, View):
-    def post(self, request, *args, **kwargs):
-        pass
+class ProfileUsernameView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
+    model = User
+    form_class = ProfileUsernameForm
+    success_url = reverse_lazy('users:profile')
+    success_message = 'ユーザ名の変更が完了しました'
+
+    def form_invalid(self, form):
+        return redirect('users:profile')

--- a/src/templates/users/profile.html
+++ b/src/templates/users/profile.html
@@ -1,13 +1,30 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>profile</title>
-</head>
-<body>
+{% extends "common/base.html" %}
+{% load static %}
+
+{% block content %}
     <h1>profile</h1>
     <p>現在のemail：{{ email }}</p>
     <p>現在のusername：{{ username }}</p>
-</body>
-</html>
+    <form action="{% url 'users:profile-email' user.id %}" method="post">
+        {% csrf_token %}
+        <label for="email">メールアドレス：</label>
+        <input type="email" name="email" value="{{ email }}">
+        <button type="submit">変更</button>
+    </form>
+    <form action="{% url 'users:profile-username' %}" method="post">
+        {% csrf_token %}
+        <label for="username">ユーザー名：</label>
+        <input type="text" name="username" value="{{ username }}">
+        <button type="submit">変更</button>
+    </form>
+    <form action="{% url 'users:profile-password' %}" method="post">
+        {% csrf_token %}
+        <label for="password">パスワード：</label>
+        <input type="password" name="password" value="">
+        <label for="password1">新しいパスワード</label>
+        <input type="password" name="password1" value="">
+        <label for="password2">新しいパスワード（確認用）</label>
+        <input type="password" name="password2" value="">
+        <button type="submit">変更</button>
+    </form>
+{% endblock %}

--- a/src/templates/users/profile.html
+++ b/src/templates/users/profile.html
@@ -46,7 +46,7 @@
 
                 <!-- 編集モード（form） -->
                 <form class="edit-row__edit {% if not open %}is-hidden{% endif %}" 
-                 data-editForm method="post" action="{% url 'users:profile-email' %}">
+                 data-editForm method="post" action="{% url 'users:profile-email' user.id %}">
                 {% csrf_token %}
                     <input type="email" name="email"
                     value="{{ email_form.email.value|default_if_none:request.user.email }}"
@@ -82,7 +82,7 @@
 
                 <!-- 編集モード（form） -->
                 <form class="edit-row__edit {% if not open %}is-hidden{% endif %}"
-                 data-editForm method="post" action="{% url 'users:profile-username' %}">
+                 data-editForm method="post" action="{% url 'users:profile-username' user.id %}">
                 {% csrf_token %}
                     <input type="text" name="username"
                      value="{{ username_form.username.value|default_if_none:request.user.username }}"
@@ -114,7 +114,7 @@
                 「パスワード変更」ボタンをクリックしてください。
             </p>
 
-            <form class="pw-form" method="post" action="{% url 'users:profile-password' %}">
+            <form class="pw-form" method="post" action="{% url 'users:profile-password' user.id %}">
                 {% csrf_token %}
                 <!-- 現在のパスワード -->
                 <div class="pw-field">
@@ -123,7 +123,7 @@
                     <div class="pw-input-wrap">
                         <input id="id_current_password" 
                          class="auth-form {% if password_form.current_password.errors %}is-error{% endif %}"
-                         type="password" name="current_password" autocomplete="current-password" data-pw>
+                         type="password" name="old_password" autocomplete="current-password" data-pw>
                         <button type="button" class="pw-toggle" aria-label="パスワードを表示" data-toggle>
                             <iconify-icon icon="uil:eye" class="pwToggleIcon"></iconify-icon>
                         </button>

--- a/src/templates/users/profile.html
+++ b/src/templates/users/profile.html
@@ -7,17 +7,19 @@
     <p>現在のusername：{{ username }}</p>
     <form action="{% url 'users:profile-email' user.id %}" method="post">
         {% csrf_token %}
+        {{ form.as_p }}
+        {{ form.email.errors }} 
         <label for="email">メールアドレス：</label>
         <input type="email" name="email" value="{{ email }}">
         <button type="submit">変更</button>
     </form>
-    <form action="{% url 'users:profile-username' %}" method="post">
+    <form action="{% url 'users:profile-username' user.id %}" method="post">
         {% csrf_token %}
         <label for="username">ユーザー名：</label>
         <input type="text" name="username" value="{{ username }}">
         <button type="submit">変更</button>
     </form>
-    <form action="{% url 'users:profile-password' %}" method="post">
+    <form action="{% url 'users:profile-password' user.id %}" method="post">
         {% csrf_token %}
         <label for="password">パスワード：</label>
         <input type="password" name="password" value="">


### PR DESCRIPTION
### 概要
プロフィールの変更処理の追加、Skip時のprogram_runs.statusでrunning, pausedに条件分岐

### 変更内容
- プロフィール変更処理（username, email, password）を追加
- 変更に伴う成功メッセージ、エラーメッセージの表示
- interrupt時のcsrfトークンを無効化
- Skip時のprogram_runs.statusでnext_timer_runs.statusをrunning, pausedに分岐、レスポンス

### 関連Issue
- Issue番号（例: #69 ）